### PR TITLE
Bump crypto version in privy-js

### DIFF
--- a/packages/privy-js/package-lock.json
+++ b/packages/privy-js/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@ethersproject/address": "^5.6.0",
-        "@privy-io/crypto": "0.0.2",
+        "@privy-io/crypto": "0.0.3",
         "axios": "^0.26.1",
         "base64-js": "^1.5.1",
         "dotenv": "^16.0.0",
@@ -995,9 +995,9 @@
       }
     },
     "node_modules/@privy-io/crypto": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@privy-io/crypto/-/crypto-0.0.2.tgz",
-      "integrity": "sha512-9km3KIxnXMNI53xaVwOT1zjOiaqn2Tl5e81NdYL0ntHBsI5FSYSfNUQWc8HcBJ0eak63HengZXb2kTGLFnEnyg=="
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@privy-io/crypto/-/crypto-0.0.3.tgz",
+      "integrity": "sha512-5HdHySLQbzohe4DxTrNiFbqKfZFafyACLNhDtmYb9ohTofHrflCnvRWgrKEdEA3G/fL7sI86uX06qE6XpnBDlQ=="
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
@@ -5186,9 +5186,9 @@
       }
     },
     "@privy-io/crypto": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@privy-io/crypto/-/crypto-0.0.2.tgz",
-      "integrity": "sha512-9km3KIxnXMNI53xaVwOT1zjOiaqn2Tl5e81NdYL0ntHBsI5FSYSfNUQWc8HcBJ0eak63HengZXb2kTGLFnEnyg=="
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@privy-io/crypto/-/crypto-0.0.3.tgz",
+      "integrity": "sha512-5HdHySLQbzohe4DxTrNiFbqKfZFafyACLNhDtmYb9ohTofHrflCnvRWgrKEdEA3G/fL7sI86uX06qE6XpnBDlQ=="
     },
     "@sinonjs/commons": {
       "version": "1.8.3",

--- a/packages/privy-js/package.json
+++ b/packages/privy-js/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@ethersproject/address": "^5.6.0",
-    "@privy-io/crypto": "0.0.2",
+    "@privy-io/crypto": "0.0.3",
     "axios": "^0.26.1",
     "base64-js": "^1.5.1",
     "dotenv": "^16.0.0",


### PR DESCRIPTION
I published privy-crypto and now updating the dependency here.