### PR TITLE
Change EncryptedUserResponse typing to ack nulls

### DIFF
--- a/packages/privy-js/src/client.ts
+++ b/packages/privy-js/src/client.ts
@@ -165,7 +165,7 @@ export class PrivyClient {
       const response = await this.api.post<EncryptedUserDataResponse>(path, {data: encryptedData});
       const result = response.data.data.map((field, index) => {
         const plaintext = encoding.toBuffer(data[index].value, 'utf8');
-        return new FieldInstance(field, plaintext, 'text/plain');
+        return new FieldInstance(field!, plaintext, 'text/plain');
       });
       return typeof fields === 'string' ? result[0] : result;
     } catch (error) {
@@ -290,7 +290,7 @@ export class PrivyClient {
         ],
       });
 
-      return new FieldInstance(response.data.data[0], plaintext, blob.type);
+      return new FieldInstance(response.data.data[0]!, plaintext, blob.type);
     } catch (error) {
       throw formatPrivyError(error);
     }
@@ -380,7 +380,7 @@ export class PrivyClient {
 
   private async decrypt(
     userId: string,
-    data: EncryptedUserDataResponseValue[],
+    data: (EncryptedUserDataResponseValue | null)[],
   ): Promise<Array<FieldInstance | null>> {
     const dataWithIndex = data.map((field, index) => ({index, field}));
 
@@ -399,12 +399,12 @@ export class PrivyClient {
     const fieldsToDecrypt = stringFieldsWithIndex.map(({field, index}) => ({
       field,
       index,
-      decryption: new x0.Decryption(encoding.toBuffer(field.value, 'base64')),
+      decryption: new x0.Decryption(encoding.toBuffer(field!.value, 'base64')),
     }));
 
     // Prepare and decrypt the data keys
     const keysToDecrypt = fieldsToDecrypt.map(({field, decryption}) => ({
-      field_id: field.field_id,
+      field_id: field!.field_id,
       wrapper_key_id: encoding.toString(decryption.wrapperKeyId(), 'utf8'),
       encrypted_key: encoding.toString(decryption.encryptedDataKey(), 'base64'),
     }));
@@ -424,14 +424,14 @@ export class PrivyClient {
 
     // Maintaining order, populate the result with the (decrypted) string field values
     for (const {index, field, plaintext} of decryptedStringFields) {
-      results[index] = new FieldInstance(field, plaintext, 'text/plain');
+      results[index] = new FieldInstance(field!, plaintext, 'text/plain');
     }
 
     // Maintaining order, populate the result with the file field values
     for (const {index, field} of fileFieldsWithIndex) {
       results[index] = new FieldInstance(
-        field,
-        encoding.toBuffer(field.value, 'utf8'),
+        field!,
+        encoding.toBuffer(field!.value, 'utf8'),
         'text/plain',
       );
     }

--- a/packages/privy-js/src/types.ts
+++ b/packages/privy-js/src/types.ts
@@ -8,7 +8,7 @@ export interface EncryptedUserDataResponseValue {
 }
 
 export interface EncryptedUserDataResponse {
-  data: EncryptedUserDataResponseValue[];
+  data: (EncryptedUserDataResponseValue | null)[];
 }
 
 export interface DataKeyResponseValue {

--- a/packages/privy-js/test/integration/index.test.ts
+++ b/packages/privy-js/test/integration/index.test.ts
@@ -1,6 +1,51 @@
 import axios from 'axios';
 import PrivyClient, {FieldInstance, CustomSession} from '../../src';
 
+const PRIVY_API = process.env.PRIVY_API || 'http://127.0.0.1:2424/v0';
+const PRIVY_KMS = process.env.PRIVY_KMS || 'http://127.0.0.1:2424/v0';
+const PRIVY_CONSOLE = process.env.PRIVY_CONSOLE || 'http://127.0.0.1:2424/console';
+
+// If these are omitted, a new API key pair will be generated using the default dev console login.
+let PRIVY_API_PUBLIC_KEY = process.env.PRIVY_API_PUBLIC_KEY || '';
+let PRIVY_API_SECRET_KEY = process.env.PRIVY_API_SECRET_KEY || '';
+
+// Convenience function to generate a new API key pair using default dev credentials.
+const fetchAPIKeys = async () => {
+  if (!PRIVY_API_PUBLIC_KEY || !PRIVY_API_SECRET_KEY) {
+    const {
+      data: {token},
+    } = await axios.post(
+      '/token',
+      {},
+      {
+        baseURL: PRIVY_CONSOLE,
+        auth: {
+          username: 'hi@acme.co',
+          password: 'acme-password1',
+        },
+      },
+    );
+    const {
+      data: {key, secret},
+    } = await axios.post(
+      '/accounts/api_keys',
+      {},
+      {
+        baseURL: PRIVY_CONSOLE,
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+    console.log('Generated API key pair:', key, ',', secret);
+    PRIVY_API_PUBLIC_KEY = key;
+    PRIVY_API_SECRET_KEY = secret;
+  }
+};
+
+beforeAll(async () => {
+  await fetchAPIKeys();
+});
 describe('Privy client', () => {
   const userID = `0x${Date.now()}`;
 
@@ -15,8 +60,8 @@ describe('Privy client', () => {
       {requester_id: userID, roles: []},
       {
         auth: {
-          username: process.env.PRIVY_API_PUBLIC_KEY as string,
-          password: process.env.PRIVY_API_SECRET_KEY as string,
+          username: PRIVY_API_PUBLIC_KEY,
+          password: PRIVY_API_SECRET_KEY,
         },
       },
     );


### PR DESCRIPTION
- The backend returns nulls for missing fields, but this is not acknowledged in our current typing. Making this explicit so type checks are accurate.
- I just made this PR quickly - I'm not sure if there's a more idiomatic way of doing this? i.e. sprinkling `field!` seems maybe non-ideal, open to suggestions.

**Testing**
- Ran `npm run test-integration` in privy-js

cc: @zacharyliu, @asta-li 