### PR TITLE
Pipe next cursor id through node

### DIFF
--- a/packages/privy-node/src/client.ts
+++ b/packages/privy-node/src/client.ts
@@ -28,7 +28,7 @@ import {
   DataKeyBatchResponse,
   DataKeyResponseValue,
 } from './types';
-import {FieldInstance, UserFieldInstances} from './fieldInstance';
+import {FieldInstance, BatchFieldInstances, UserFieldInstances} from './fieldInstance';
 import {formatPrivyError, PrivyClientError} from './errors';
 import encoding, {wrapAsBuffer} from './encoding';
 import {md5} from './hash';
@@ -139,13 +139,13 @@ export class PrivyClient {
   async getBatch(
     fields: string | string[],
     options: BatchOptions = {},
-  ): Promise<Array<UserFieldInstances>> {
+  ): Promise<BatchFieldInstances> {
     const path = batchUserDataPath(wrap(fields), options);
 
     try {
       const response = await this.api.get<BatchEncryptedUserDataResponse>(path);
       const decrypted = await this.decryptBatch(wrap(fields), response.data);
-      return decrypted;
+      return {next_cursor_id: response.data.next_cursor_id, users: decrypted};
     } catch (error) {
       throw formatPrivyError(error);
     }

--- a/packages/privy-node/src/fieldInstance.ts
+++ b/packages/privy-node/src/fieldInstance.ts
@@ -1,6 +1,11 @@
 import encoding, {wrapAsBuffer} from './encoding';
 import {EncryptedUserDataResponseValue} from './types';
 
+export type BatchFieldInstances = {
+  next_cursor_id: string;
+  users: Array<UserFieldInstances>;
+};
+
 export type UserFieldInstances = {
   user_id: string;
   data: (FieldInstance | null)[];

--- a/packages/privy-node/src/index.ts
+++ b/packages/privy-node/src/index.ts
@@ -3,8 +3,10 @@ import {PrivyClient} from './client';
 export {Session} from './sessions';
 export {CustomSession} from './sessions/custom';
 
-export {FieldInstance, UserFieldInstances} from './fieldInstance';
+export {FieldInstance, BatchFieldInstances, UserFieldInstances} from './fieldInstance';
 
 export {PrivyError, PrivyApiError, PrivyClientError, PrivySessionError} from './errors';
+
+export {BatchOptions} from './types';
 
 export default PrivyClient;

--- a/packages/privy-node/src/types.ts
+++ b/packages/privy-node/src/types.ts
@@ -15,6 +15,7 @@ export interface EncryptedUserDataResponse {
 // BatchEncryptedUserDataResponse is densely populated i.e. it contains an entry for every user
 // and field, even if the field has no data.
 export interface BatchEncryptedUserDataResponse {
+  next_cursor_id: string;
   users: EncryptedUserDataResponse[];
 }
 

--- a/packages/privy-node/test/integration/index.test.ts
+++ b/packages/privy-node/test/integration/index.test.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import PrivyClient, {FieldInstance, UserFieldInstances, CustomSession} from '../../src';
+import PrivyClient, {FieldInstance, BatchOptions, CustomSession} from '../../src';
 
 const PRIVY_API = process.env.PRIVY_API || 'http://127.0.0.1:2424/v0';
 const PRIVY_KMS = process.env.PRIVY_KMS || 'http://127.0.0.1:2424/v0';
@@ -163,18 +163,23 @@ describe('Privy admin client', () => {
     ]);
     const user1 = `0x${Date.now()}`;
     [username] = await client.put(user1, [{field: 'username', value: 'michael'}]);
+    const user2 = `0x${Date.now()}`;
+    [username] = await client.put(user2, [{field: 'username', value: 'gob'}]);
 
     // Test missing cursor behavior.
-    let users = (await client.getBatch(['username', 'email'], {
-      limit: 2,
-    })) as UserFieldInstances[];
-    expect(users.length).toEqual(2);
+    let options: BatchOptions = {limit: 1};
+    let batchData = await client.getBatch(['username', 'email'], {
+      limit: 1,
+    });
+    expect(batchData.next_cursor_id).toEqual(user1);
+    expect(batchData.users.length).toEqual(1);
 
     // Test data returned when cursor is provided.
-    users = (await client.getBatch(['username', 'email'], {
+    batchData = await client.getBatch(['username', 'email'], {
       cursor: user1,
       limit: 2,
-    })) as UserFieldInstances[];
+    });
+    let users = batchData.users;
     expect(users.length).toEqual(2);
     // Check user0's data.
     expect(users[0].data.length).toEqual(2);


### PR DESCRIPTION
As part of docs, I realized I'd left off piping `next_cursor_id` through the node api. Including here.

**Testing done**
Confirmed that `npm run test-integration` still passes `index.test.ts`.

