### PR TITLE
Revert pagination changes in node to unblock shipping privy-node

### DIFF
--- a/packages/privy-node/src/client.ts
+++ b/packages/privy-node/src/client.ts
@@ -4,8 +4,6 @@ import {Http} from './http';
 import {Session} from './sessions';
 import {PRIVY_API_URL, PRIVY_KMS_URL, DEFAULT_TIMEOUT_MS} from './constants';
 import {
-  batchDataKeyPath,
-  batchUserDataPath,
   dataKeyPath,
   fileDownloadsPath,
   fileUploadsPath,
@@ -15,20 +13,14 @@ import {
 } from './paths';
 import {wrap} from './utils';
 import {
-  BatchOptions,
-  BatchEncryptedUserDataResponse,
-  DataKeyUserResponse,
+  DataKeyResponse,
   EncryptedUserDataResponse,
   EncryptedUserDataResponseValue,
   EncryptedUserDataRequestValue,
   FileMetadata,
   WrapperKeyResponse,
-  DataKeyUserRequest,
-  DataKeyBatchRequest,
-  DataKeyBatchResponse,
-  DataKeyResponseValue,
 } from './types';
-import {FieldInstance, BatchFieldInstances, UserFieldInstances} from './fieldInstance';
+import {FieldInstance} from './fieldInstance';
 import {formatPrivyError, PrivyClientError} from './errors';
 import encoding, {wrapAsBuffer} from './encoding';
 import {md5} from './hash';
@@ -123,29 +115,6 @@ export class PrivyClient {
       const response = await this.api.get<EncryptedUserDataResponse>(path);
       const decrypted = await this.decrypt(userId, response.data.data);
       return typeof fields === 'string' ? decrypted[0] : decrypted;
-    } catch (error) {
-      throw formatPrivyError(error);
-    }
-  }
-
-  /**
-   * Get a batch of admin-accessible user data from the Privy API, indexed by user ID.
-   *
-   * @param fields: String field name or an array of string field names.
-   * @param options Optional object containing batch request configuration.
-   * @param options.cursor Optional user ID to start from. Returned by previous call to `getBatch`.
-   * @param options.limit Optional maximum number of users to return.
-   */
-  async getBatch(
-    fields: string | string[],
-    options: BatchOptions = {},
-  ): Promise<BatchFieldInstances> {
-    const path = batchUserDataPath(wrap(fields), options);
-
-    try {
-      const response = await this.api.get<BatchEncryptedUserDataResponse>(path);
-      const decrypted = await this.decryptBatch(wrap(fields), response.data);
-      return {next_cursor_id: response.data.next_cursor_id, users: decrypted};
     } catch (error) {
       throw formatPrivyError(error);
     }
@@ -444,7 +413,7 @@ export class PrivyClient {
       wrapper_key_id: encoding.toString(decryption.wrapperKeyId(), 'utf8'),
       encrypted_key: encoding.toString(decryption.encryptedDataKey(), 'base64'),
     }));
-    const decryptedKeys = await this.decryptKeys({user_id: userId, data: keysToDecrypt});
+    const decryptedKeys = await this.decryptKeys(userId, keysToDecrypt);
 
     // Using the data keys from previous step, decrypt all fields in need of decryption
     const decryptedStringFields = await Promise.all(
@@ -517,7 +486,7 @@ export class PrivyClient {
       encrypted_key: encoding.toString(decryption.encryptedDataKey(), 'base64'),
     };
 
-    const [dataKey] = await this.decryptKeys({user_id: userId, data: [keyToDecrypt]});
+    const [dataKey] = await this.decryptKeys(userId, [keyToDecrypt]);
     const result = await decryption.decrypt(dataKey);
 
     return result.plaintext();
@@ -536,7 +505,7 @@ export class PrivyClient {
       encrypted_key: encoding.toString(decryption.encryptedDataKey(), 'base64'),
     };
 
-    const [dataKey] = await this.decryptKeys({user_id: field.user_id, data: [keyToDecrypt]});
+    const [dataKey] = await this.decryptKeys(field.user_id, [keyToDecrypt]);
 
     const result = await decryption.decrypt(dataKey);
 
@@ -569,120 +538,15 @@ export class PrivyClient {
     }));
   }
 
-  async decryptKeys(request: DataKeyUserRequest): Promise<Uint8Array[]> {
-    if (request.data.length === 0) {
+  async decryptKeys(
+    userId: string,
+    keys: {field_id: string; wrapper_key_id: string; encrypted_key: string}[],
+  ): Promise<Uint8Array[]> {
+    if (keys.length === 0) {
       return [];
     }
-    const path = dataKeyPath(request.user_id);
-    const response = await this.kms.post<DataKeyUserResponse>(path, request);
+    const path = dataKeyPath(userId);
+    const response = await this.kms.post<DataKeyResponse>(path, {data: keys});
     return response.data.data.map(({key}) => encoding.toBuffer(key, 'base64'));
-  }
-
-  /**
-   * Calls the KMS to decrypt the given data keys.
-   * @param request The DataKeyBatchRequest to send to the KMS.
-   * @returns 2-D Array of decrypted batch keys ordered by the same ordering of user, field as the
-   * request, mapping to the decrypted key if it exists or `null` otherwise.
-   */
-  async decryptBatchKeys(request: DataKeyBatchRequest): Promise<(Uint8Array | null)[][]> {
-    if (request.users.length === 0) {
-      return new Array<Array<Uint8Array>>();
-    }
-    const path = batchDataKeyPath();
-    const response = await this.kms.post<DataKeyBatchResponse>(path, request);
-    const keyToBuffer = (value: DataKeyResponseValue) =>
-      value.key === null ? null : encoding.toBuffer(value.key, 'base64');
-    return response.data.users.map((userResponse) => userResponse.data.map(keyToBuffer));
-  }
-
-  /**
-   * Decrypts the given encrypted batch data response and returns an array of UserFieldInstances in the
-   * same order as the response.
-   * @param fieldIDs The field IDs of the fields to decrypt.
-   * @param batchDataResponse The response from the API with encrypted data.
-   * @returns Array of UserFieldInstances in the same order as the response.
-   */
-  private async decryptBatch(
-    fieldIDs: string[],
-    batchDataResponse: BatchEncryptedUserDataResponse,
-  ): Promise<Array<UserFieldInstances>> {
-    if (batchDataResponse.users.length === 0) {
-      return [];
-    }
-    // Check that only string fields are requested. We don't handle files here.
-    // Create decryption instances.
-    const decryptionInstances = batchDataResponse.users.map((user) => {
-      const fieldDecryptions = fieldIDs.map((_, fieldIdx) => {
-        const field = user.data[fieldIdx];
-        // Check that only non-files are attempted to be decrypted.
-        if (field !== null && field.object_type === 'file') {
-          throw new PrivyClientError('Batch decryption of files is not supported');
-        }
-        return field === null ? null : new x0.Decryption(encoding.toBuffer(field.value, 'base64'));
-      });
-      return fieldDecryptions;
-    });
-
-    // Get data keys.
-    const dataKeyRequests: Array<DataKeyUserRequest> = batchDataResponse.users.map(
-      (user, userIdx) => {
-        const dataKeyRequests = fieldIDs.map((fieldID, fieldIdx) => {
-          const decryption = decryptionInstances[userIdx][fieldIdx];
-          return {
-            field_id: fieldID,
-            wrapper_key_id:
-              decryption === null ? null : encoding.toString(decryption.wrapperKeyId(), 'utf8'),
-            encrypted_key:
-              decryption === null
-                ? null
-                : encoding.toString(decryption.encryptedDataKey(), 'base64'),
-          };
-        });
-        return {user_id: user.user_id, data: dataKeyRequests};
-      },
-    );
-
-    const decryptedKeys: (Uint8Array | null)[][] = await this.decryptBatchKeys({
-      users: dataKeyRequests,
-    });
-
-    // Build decrypted field matrix.
-    const decryptedFields: (Uint8Array | null)[][] = await Promise.all(
-      batchDataResponse.users.map(async (_, userIdx): Promise<(Uint8Array | null)[]> => {
-        return await Promise.all(
-          fieldIDs.map(async (_, fieldIdx) => {
-            const dataKey = decryptedKeys[userIdx][fieldIdx];
-            if (dataKey === null) {
-              return null;
-            } else {
-              const decryption = decryptionInstances[userIdx][fieldIdx];
-              if (decryption === null) {
-                return null;
-              } else {
-                const result = await decryption.decrypt(dataKey);
-                return result.plaintext();
-              }
-            }
-          }),
-        );
-      }),
-    );
-
-    // Collect results into userFieldInstances.
-    const userIDs = batchDataResponse.users.map((user) => user.user_id);
-    var userFieldInstances = new Array<UserFieldInstances>();
-    userFieldInstances = userIDs.map((userID, userIdx) => {
-      const fields = batchDataResponse.users[userIdx].data;
-      const plaintext = decryptedFields[userIdx];
-      const fieldInstances = fieldIDs.map((_, fieldIdx) => {
-        if (fields[fieldIdx] === null || plaintext[fieldIdx] === null) {
-          return null;
-        } else {
-          return new FieldInstance(fields[fieldIdx]!, plaintext[fieldIdx]!, 'text/plain');
-        }
-      });
-      return {user_id: userID, data: fieldInstances};
-    });
-    return userFieldInstances;
   }
 }

--- a/packages/privy-node/src/fieldInstance.ts
+++ b/packages/privy-node/src/fieldInstance.ts
@@ -1,16 +1,6 @@
 import encoding, {wrapAsBuffer} from './encoding';
 import {EncryptedUserDataResponseValue} from './types';
 
-export type BatchFieldInstances = {
-  next_cursor_id: string;
-  users: Array<UserFieldInstances>;
-};
-
-export type UserFieldInstances = {
-  user_id: string;
-  data: (FieldInstance | null)[];
-};
-
 export class FieldInstance {
   private attributes: EncryptedUserDataResponseValue;
   private plaintext: Uint8Array;

--- a/packages/privy-node/src/index.ts
+++ b/packages/privy-node/src/index.ts
@@ -3,10 +3,8 @@ import {PrivyClient} from './client';
 export {Session} from './sessions';
 export {CustomSession} from './sessions/custom';
 
-export {FieldInstance, BatchFieldInstances, UserFieldInstances} from './fieldInstance';
+export {FieldInstance} from './fieldInstance';
 
 export {PrivyError, PrivyApiError, PrivyClientError, PrivySessionError} from './errors';
-
-export {BatchOptions} from './types';
 
 export default PrivyClient;

--- a/packages/privy-node/src/paths.ts
+++ b/packages/privy-node/src/paths.ts
@@ -1,29 +1,8 @@
-import {BatchOptions} from './types';
-
 export const userDataPath = (userId: string, fields?: string[]) => {
   const path = `/users/${userId}/data`;
   const query = ['new=t'];
 
-  if (fields && fields.length > 0) {
-    const uriEncodedFields = fields.map(encodeURIComponent);
-    query.push(`fields=${uriEncodedFields.join(',')}`);
-  }
-
-  return `${path}?${query.join('&')}`;
-};
-
-export const batchUserDataPath = (fields: string[], options: BatchOptions) => {
-  const path = `/data`;
-  const query = [];
-
-  if (options.cursor) {
-    query.push(`cursor=${options.cursor}`);
-  }
-  if (options.limit) {
-    query.push(`limit=${options.limit}`);
-  }
-
-  if (fields && fields.length > 0) {
+  if (Array.isArray(fields) && fields.length > 0) {
     const uriEncodedFields = fields.map(encodeURIComponent);
     query.push(`fields=${uriEncodedFields.join(',')}`);
   }
@@ -33,10 +12,6 @@ export const batchUserDataPath = (fields: string[], options: BatchOptions) => {
 
 export const dataKeyPath = (userId: string) => {
   return `/key_manager/users/${userId}/data_key`;
-};
-
-export const batchDataKeyPath = () => {
-  return `/key_manager/data_key`;
 };
 
 export const wrapperKeyPath = (userId: string) => {

--- a/packages/privy-node/src/types.ts
+++ b/packages/privy-node/src/types.ts
@@ -8,45 +8,15 @@ export interface EncryptedUserDataResponseValue {
 }
 
 export interface EncryptedUserDataResponse {
-  user_id: string;
   data: EncryptedUserDataResponseValue[];
-}
-
-// BatchEncryptedUserDataResponse is densely populated i.e. it contains an entry for every user
-// and field, even if the field has no data.
-export interface BatchEncryptedUserDataResponse {
-  next_cursor_id: string;
-  users: EncryptedUserDataResponse[];
 }
 
 export interface DataKeyResponseValue {
   key: string; // Data key as base64 string.
 }
 
-export interface DataKeyUserResponse {
-  user_id: string;
+export interface DataKeyResponse {
   data: DataKeyResponseValue[];
-}
-
-export interface DataKeyBatchResponse {
-  users: DataKeyUserResponse[];
-}
-
-export interface DataKeyRequest {
-  field_id: string;
-  wrapper_key_id: string | null;
-  encrypted_key: string | null;
-}
-
-// DataKeyUserRequest must be densely populated i.e. it contains an entry for every user and
-// field, even if the encrypted_key in DataKeyRequest is null.
-export interface DataKeyUserRequest {
-  user_id: string;
-  data: DataKeyRequest[];
-}
-
-export interface DataKeyBatchRequest {
-  users: DataKeyUserRequest[];
 }
 
 export interface EncryptedUserDataRequestValue {
@@ -74,9 +44,4 @@ export interface FileMetadata {
   content_type: string;
   commitment_id: string;
   created_at: number;
-}
-
-export interface BatchOptions {
-  cursor?: string;
-  limit?: number;
 }

--- a/packages/privy-node/test/integration/index.test.ts
+++ b/packages/privy-node/test/integration/index.test.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import PrivyClient, {FieldInstance, BatchOptions, CustomSession} from '../../src';
+import PrivyClient, {FieldInstance, CustomSession} from '../../src';
 
 const PRIVY_API = process.env.PRIVY_API || 'http://127.0.0.1:2424/v0';
 const PRIVY_KMS = process.env.PRIVY_KMS || 'http://127.0.0.1:2424/v0';
@@ -125,73 +125,5 @@ describe('Privy client', () => {
     const downloadedFile = await client.getFile(userID, 'avatar');
     expect(downloadedFile!.buffer().toString()).toEqual('file_data');
     expect(downloadedFile!.contentType).toEqual('text/plain');
-  });
-});
-
-describe('Privy admin client', () => {
-  // In production code, this would likely be setup to hit
-  // a backend that would then call Privy so that the API
-  // secret key is not exposed on clients. However, any
-  // async function that returns a string JWT that Privy
-  // can recognize the signature of is valid.
-  const customSession = new CustomSession(async function authenticate() {
-    const response = await axios.post<{token: string}>(
-      `${PRIVY_API}/auth/token`,
-      {requester_id: 'admin_id', roles: ['admin']},
-      {
-        auth: {
-          username: PRIVY_API_PUBLIC_KEY,
-          password: PRIVY_API_SECRET_KEY,
-        },
-      },
-    );
-    return response.data.token;
-  });
-
-  const client = new PrivyClient({
-    apiURL: PRIVY_API,
-    kmsURL: PRIVY_KMS,
-    session: customSession,
-  });
-
-  it('batch get / put api', async () => {
-    const user0 = `0x${Date.now()}`;
-    let username: FieldInstance | null, email: FieldInstance | null;
-    [username, email] = await client.put(user0, [
-      {field: 'username', value: 'tobias'},
-      {field: 'email', value: 'tobias@funke.com'},
-    ]);
-    const user1 = `0x${Date.now()}`;
-    [username] = await client.put(user1, [{field: 'username', value: 'michael'}]);
-    const user2 = `0x${Date.now()}`;
-    [username] = await client.put(user2, [{field: 'username', value: 'gob'}]);
-
-    // Test missing cursor behavior.
-    let options: BatchOptions = {limit: 1};
-    let batchData = await client.getBatch(['username', 'email'], {
-      limit: 1,
-    });
-    expect(batchData.next_cursor_id).toEqual(user1);
-    expect(batchData.users.length).toEqual(1);
-
-    // Test data returned when cursor is provided.
-    batchData = await client.getBatch(['username', 'email'], {
-      cursor: user1,
-      limit: 2,
-    });
-    let users = batchData.users;
-    expect(users.length).toEqual(2);
-    // Check user0's data.
-    expect(users[0].data.length).toEqual(2);
-    username = users[0].data[0] as FieldInstance;
-    expect(username.text()).toEqual('michael');
-    email = users[0].data[1] as FieldInstance;
-    expect(email).toEqual(null);
-    // Check user1's data.
-    expect(users[1].data.length).toEqual(2);
-    username = users[1].data[0] as FieldInstance;
-    expect(username.text()).toEqual('tobias');
-    email = users[1].data[1] as FieldInstance;
-    expect(email.text()).toEqual('tobias@funke.com');
   });
 });


### PR DESCRIPTION
- I suspect there's an issue in old perms that causing pagination failure. Rolling back pagination to unblock shipping privy node first, then will either fix, or more likely just migrate pagination to new perms.

**Testing done**
- Checked that index.test.ts still passes on `npm run test-integration`