### PR TITLE
Quick fix to unbreak tests - use "admin" requester ID to pass "self" permissions

### DIFF
--- a/packages/privy-node/test/integration/index.test.ts
+++ b/packages/privy-node/test/integration/index.test.ts
@@ -47,7 +47,7 @@ beforeAll(async () => {
 });
 
 describe('Privy client', () => {
-  const userID = `0x${Date.now()}`;
+  const userID = `admin`;
 
   let client: PrivyClient;
 


### PR DESCRIPTION
Quick fix to unbreak tests - use "admin" requester ID to pass "self" permissions

The fields in the tests have "self" permissions set, but the access token used in Privy Node is an admin token. As a quick workaround we just request data corresponding to the "admin" user ID.

The more correct solution changes the fields to readable by admins. Following up with that shortly.