### PR TITLE
Reland pagination client

### DIFF
--- a/packages/privy-node/src/client.ts
+++ b/packages/privy-node/src/client.ts
@@ -3,6 +3,8 @@ import {CryptoEngine, CryptoVersion} from '@privy-io/crypto';
 import {Http} from './http';
 import {PRIVY_API_URL, PRIVY_KMS_URL, DEFAULT_TIMEOUT_MS, REQUESTER_ID_ADMIN} from './constants';
 import {
+  batchDataKeyPath,
+  batchUserDataPath,
   dataKeyPath,
   fileDownloadsPath,
   fileUploadsPath,
@@ -12,14 +14,20 @@ import {
 } from './paths';
 import {wrap} from './utils';
 import {
-  DataKeyResponse,
+  BatchOptions,
+  BatchEncryptedUserDataResponse,
+  DataKeyUserResponse,
   EncryptedUserDataResponse,
   EncryptedUserDataResponseValue,
   EncryptedUserDataRequestValue,
   FileMetadata,
   WrapperKeyResponse,
+  DataKeyUserRequest,
+  DataKeyBatchRequest,
+  DataKeyBatchResponse,
+  DataKeyResponseValue,
 } from './types';
-import {FieldInstance} from './fieldInstance';
+import {FieldInstance, BatchFieldInstances, UserFieldInstances} from './fieldInstance';
 import {formatPrivyError, PrivyClientError} from './errors';
 import encoding, {wrapAsBuffer} from './encoding';
 import {md5} from './hash';
@@ -131,6 +139,29 @@ export class PrivyClient extends PrivyConfig {
       const response = await this.api.get<EncryptedUserDataResponse>(path);
       const decrypted = await this.decrypt(userId, response.data.data);
       return typeof fields === 'string' ? decrypted[0] : decrypted;
+    } catch (error) {
+      throw formatPrivyError(error);
+    }
+  }
+
+  /**
+   * Get a batch of admin-accessible user data from the Privy API, indexed by user ID.
+   *
+   * @param fields: String field name or an array of string field names.
+   * @param options Optional object containing batch request configuration.
+   * @param options.cursor Optional user ID to start from. Returned by previous call to `getBatch`.
+   * @param options.limit Optional maximum number of users to return.
+   */
+  async getBatch(
+    fields: string | string[],
+    options: BatchOptions = {},
+  ): Promise<BatchFieldInstances> {
+    const path = batchUserDataPath(wrap(fields), options);
+
+    try {
+      const response = await this.api.get<BatchEncryptedUserDataResponse>(path);
+      const decrypted = await this.decryptBatch(wrap(fields), response.data);
+      return {next_cursor_id: response.data.next_cursor_id, users: decrypted};
     } catch (error) {
       throw formatPrivyError(error);
     }
@@ -429,7 +460,7 @@ export class PrivyClient extends PrivyConfig {
       wrapper_key_id: encoding.toString(decryption.wrapperKeyId(), 'utf8'),
       encrypted_key: encoding.toString(decryption.encryptedDataKey(), 'base64'),
     }));
-    const decryptedKeys = await this.decryptKeys(userId, keysToDecrypt);
+    const decryptedKeys = await this.decryptKeys({user_id: userId, data: keysToDecrypt});
 
     // Using the data keys from previous step, decrypt all fields in need of decryption
     const decryptedStringFields = await Promise.all(
@@ -502,7 +533,7 @@ export class PrivyClient extends PrivyConfig {
       encrypted_key: encoding.toString(decryption.encryptedDataKey(), 'base64'),
     };
 
-    const [dataKey] = await this.decryptKeys(userId, [keyToDecrypt]);
+    const [dataKey] = await this.decryptKeys({user_id: userId, data: [keyToDecrypt]});
     const result = await decryption.decrypt(dataKey);
 
     return result.plaintext();
@@ -521,7 +552,7 @@ export class PrivyClient extends PrivyConfig {
       encrypted_key: encoding.toString(decryption.encryptedDataKey(), 'base64'),
     };
 
-    const [dataKey] = await this.decryptKeys(field.user_id, [keyToDecrypt]);
+    const [dataKey] = await this.decryptKeys({user_id: field.user_id, data: [keyToDecrypt]});
 
     const result = await decryption.decrypt(dataKey);
 
@@ -554,15 +585,120 @@ export class PrivyClient extends PrivyConfig {
     }));
   }
 
-  async decryptKeys(
-    userId: string,
-    keys: {field_id: string; wrapper_key_id: string; encrypted_key: string}[],
-  ): Promise<Uint8Array[]> {
-    if (keys.length === 0) {
+  async decryptKeys(request: DataKeyUserRequest): Promise<Uint8Array[]> {
+    if (request.data.length === 0) {
       return [];
     }
-    const path = dataKeyPath(userId);
-    const response = await this.kms.post<DataKeyResponse>(path, {data: keys});
+    const path = dataKeyPath(request.user_id);
+    const response = await this.kms.post<DataKeyUserResponse>(path, request);
     return response.data.data.map(({key}) => encoding.toBuffer(key, 'base64'));
+  }
+
+  /**
+   * Calls the KMS to decrypt the given data keys.
+   * @param request The DataKeyBatchRequest to send to the KMS.
+   * @returns 2-D Array of decrypted batch keys ordered by the same ordering of user, field as the
+   * request, mapping to the decrypted key if it exists or `null` otherwise.
+   */
+  async decryptBatchKeys(request: DataKeyBatchRequest): Promise<(Uint8Array | null)[][]> {
+    if (request.users.length === 0) {
+      return new Array<Array<Uint8Array>>();
+    }
+    const path = batchDataKeyPath();
+    const response = await this.kms.post<DataKeyBatchResponse>(path, request);
+    const keyToBuffer = (value: DataKeyResponseValue) =>
+      value.key === null ? null : encoding.toBuffer(value.key, 'base64');
+    return response.data.users.map((userResponse) => userResponse.data.map(keyToBuffer));
+  }
+
+  /**
+   * Decrypts the given encrypted batch data response and returns an array of UserFieldInstances in the
+   * same order as the response.
+   * @param fieldIDs The field IDs of the fields to decrypt.
+   * @param batchDataResponse The response from the API with encrypted data.
+   * @returns Array of UserFieldInstances in the same order as the response.
+   */
+  private async decryptBatch(
+    fieldIDs: string[],
+    batchDataResponse: BatchEncryptedUserDataResponse,
+  ): Promise<Array<UserFieldInstances>> {
+    if (batchDataResponse.users.length === 0) {
+      return [];
+    }
+    // Check that only string fields are requested. We don't handle files here.
+    // Create decryption instances.
+    const decryptionInstances = batchDataResponse.users.map((user) => {
+      const fieldDecryptions = fieldIDs.map((_, fieldIdx) => {
+        const field = user.data[fieldIdx];
+        // Check that only non-files are attempted to be decrypted.
+        if (field !== null && field.object_type === 'file') {
+          throw new PrivyClientError('Batch decryption of files is not supported');
+        }
+        return field === null ? null : new x0.Decryption(encoding.toBuffer(field.value, 'base64'));
+      });
+      return fieldDecryptions;
+    });
+
+    // Get data keys.
+    const dataKeyRequests: Array<DataKeyUserRequest> = batchDataResponse.users.map(
+      (user, userIdx) => {
+        const dataKeyRequests = fieldIDs.map((fieldID, fieldIdx) => {
+          const decryption = decryptionInstances[userIdx][fieldIdx];
+          return {
+            field_id: fieldID,
+            wrapper_key_id:
+              decryption === null ? null : encoding.toString(decryption.wrapperKeyId(), 'utf8'),
+            encrypted_key:
+              decryption === null
+                ? null
+                : encoding.toString(decryption.encryptedDataKey(), 'base64'),
+          };
+        });
+        return {user_id: user.user_id, data: dataKeyRequests};
+      },
+    );
+
+    const decryptedKeys: (Uint8Array | null)[][] = await this.decryptBatchKeys({
+      users: dataKeyRequests,
+    });
+
+    // Build decrypted field matrix.
+    const decryptedFields: (Uint8Array | null)[][] = await Promise.all(
+      batchDataResponse.users.map(async (_, userIdx): Promise<(Uint8Array | null)[]> => {
+        return await Promise.all(
+          fieldIDs.map(async (_, fieldIdx) => {
+            const dataKey = decryptedKeys[userIdx][fieldIdx];
+            if (dataKey === null) {
+              return null;
+            } else {
+              const decryption = decryptionInstances[userIdx][fieldIdx];
+              if (decryption === null) {
+                return null;
+              } else {
+                const result = await decryption.decrypt(dataKey);
+                return result.plaintext();
+              }
+            }
+          }),
+        );
+      }),
+    );
+
+    // Collect results into userFieldInstances.
+    const userIDs = batchDataResponse.users.map((user) => user.user_id);
+    var userFieldInstances = new Array<UserFieldInstances>();
+    userFieldInstances = userIDs.map((userID, userIdx) => {
+      const fields = batchDataResponse.users[userIdx].data;
+      const plaintext = decryptedFields[userIdx];
+      const fieldInstances = fieldIDs.map((_, fieldIdx) => {
+        if (fields[fieldIdx] === null || plaintext[fieldIdx] === null) {
+          return null;
+        } else {
+          return new FieldInstance(fields[fieldIdx]!, plaintext[fieldIdx]!, 'text/plain');
+        }
+      });
+      return {user_id: userID, data: fieldInstances};
+    });
+    return userFieldInstances;
   }
 }

--- a/packages/privy-node/src/fieldInstance.ts
+++ b/packages/privy-node/src/fieldInstance.ts
@@ -1,6 +1,16 @@
 import encoding, {wrapAsBuffer} from './encoding';
 import {EncryptedUserDataResponseValue} from './types';
 
+export type BatchFieldInstances = {
+  next_cursor_id: string;
+  users: Array<UserFieldInstances>;
+};
+
+export type UserFieldInstances = {
+  user_id: string;
+  data: (FieldInstance | null)[];
+};
+
 export class FieldInstance {
   private attributes: EncryptedUserDataResponseValue;
   private plaintext: Uint8Array;

--- a/packages/privy-node/src/index.ts
+++ b/packages/privy-node/src/index.ts
@@ -1,5 +1,7 @@
 export {PrivyClient} from './client';
 
-export {FieldInstance} from './fieldInstance';
+export {FieldInstance, BatchFieldInstances, UserFieldInstances} from './fieldInstance';
 
 export {PrivyError, PrivyApiError, PrivyClientError} from './errors';
+
+export {BatchOptions} from './types';

--- a/packages/privy-node/src/paths.ts
+++ b/packages/privy-node/src/paths.ts
@@ -1,8 +1,29 @@
+import {BatchOptions} from './types';
+
 export const userDataPath = (userId: string, fields?: string[]) => {
   const path = `/users/${userId}/data`;
   const query = ['new=t'];
 
-  if (Array.isArray(fields) && fields.length > 0) {
+  if (fields && fields.length > 0) {
+    const uriEncodedFields = fields.map(encodeURIComponent);
+    query.push(`fields=${uriEncodedFields.join(',')}`);
+  }
+
+  return `${path}?${query.join('&')}`;
+};
+
+export const batchUserDataPath = (fields: string[], options: BatchOptions) => {
+  const path = `/data`;
+  const query = [];
+
+  if (options.cursor) {
+    query.push(`cursor=${options.cursor}`);
+  }
+  if (options.limit) {
+    query.push(`limit=${options.limit}`);
+  }
+
+  if (fields && fields.length > 0) {
     const uriEncodedFields = fields.map(encodeURIComponent);
     query.push(`fields=${uriEncodedFields.join(',')}`);
   }
@@ -12,6 +33,10 @@ export const userDataPath = (userId: string, fields?: string[]) => {
 
 export const dataKeyPath = (userId: string) => {
   return `/key_manager/users/${userId}/data_key`;
+};
+
+export const batchDataKeyPath = () => {
+  return `/key_manager/data_key`;
 };
 
 export const wrapperKeyPath = (userId: string) => {

--- a/packages/privy-node/src/types.ts
+++ b/packages/privy-node/src/types.ts
@@ -8,15 +8,45 @@ export interface EncryptedUserDataResponseValue {
 }
 
 export interface EncryptedUserDataResponse {
+  user_id: string;
   data: EncryptedUserDataResponseValue[];
+}
+
+// BatchEncryptedUserDataResponse is densely populated i.e. it contains an entry for every user
+// and field, even if the field has no data.
+export interface BatchEncryptedUserDataResponse {
+  next_cursor_id: string;
+  users: EncryptedUserDataResponse[];
 }
 
 export interface DataKeyResponseValue {
   key: string; // Data key as base64 string.
 }
 
-export interface DataKeyResponse {
+export interface DataKeyUserResponse {
+  user_id: string;
   data: DataKeyResponseValue[];
+}
+
+export interface DataKeyBatchResponse {
+  users: DataKeyUserResponse[];
+}
+
+export interface DataKeyRequest {
+  field_id: string;
+  wrapper_key_id: string | null;
+  encrypted_key: string | null;
+}
+
+// DataKeyUserRequest must be densely populated i.e. it contains an entry for every user and
+// field, even if the encrypted_key in DataKeyRequest is null.
+export interface DataKeyUserRequest {
+  user_id: string;
+  data: DataKeyRequest[];
+}
+
+export interface DataKeyBatchRequest {
+  users: DataKeyUserRequest[];
 }
 
 export interface EncryptedUserDataRequestValue {
@@ -44,4 +74,9 @@ export interface FileMetadata {
   content_type: string;
   commitment_id: string;
   created_at: number;
+}
+
+export interface BatchOptions {
+  cursor?: string;
+  limit?: number;
 }

--- a/packages/privy-node/test/integration/api_keys.ts
+++ b/packages/privy-node/test/integration/api_keys.ts
@@ -1,0 +1,31 @@
+import axios from 'axios';
+
+export async function fetchAPIKeys(consoleUrl: string) {
+  const {
+    data: {token},
+  } = await axios.post(
+    '/token',
+    {},
+    {
+      baseURL: consoleUrl,
+      auth: {
+        username: 'hi@acme.co',
+        password: 'acme-password1',
+      },
+    },
+  );
+  const {
+    data: {key, secret},
+  } = await axios.post(
+    '/accounts/api_keys',
+    {},
+    {
+      baseURL: consoleUrl,
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  );
+  console.log('Generated API key pair:', key, ',', secret);
+  return {key, secret};
+}

--- a/packages/privy-node/test/integration/config.test.ts
+++ b/packages/privy-node/test/integration/config.test.ts
@@ -1,17 +1,31 @@
 import {PrivyClient} from '../../src';
+import {fetchAPIKeys} from './api_keys';
 import uniqueId from '../unique_id';
+
+const PRIVY_API_URL = process.env.PRIVY_API_URL || 'http://127.0.0.1:2424/v0';
+const PRIVY_KMS_URL = process.env.PRIVY_KMS_URL || 'http://127.0.0.1:2424/v0';
+const PRIVY_CONSOLE = process.env.PRIVY_CONSOLE || 'http://127.0.0.1:2424/console';
+
+// If these are omitted, a new API key pair will be generated using the default dev console login.
+let PRIVY_API_PUBLIC_KEY = process.env.PRIVY_API_PUBLIC_KEY || '';
+let PRIVY_API_SECRET_KEY = process.env.PRIVY_API_SECRET_KEY || '';
 
 describe('PrivyNode', () => {
   let privyNode: PrivyClient;
 
   beforeEach(async () => {
+    if (!PRIVY_API_PUBLIC_KEY || !PRIVY_API_SECRET_KEY) {
+      const keyPair = await fetchAPIKeys(PRIVY_CONSOLE);
+      PRIVY_API_PUBLIC_KEY = keyPair.key;
+      PRIVY_API_SECRET_KEY = keyPair.secret;
+    }
     // Create a config API instance.
     privyNode = new PrivyClient(
-      process.env.PRIVY_API_PUBLIC_KEY!,
-      process.env.PRIVY_API_SECRET_KEY!,
+      PRIVY_API_PUBLIC_KEY!,
+      PRIVY_API_SECRET_KEY!,
       {
-        apiURL: process.env.PRIVY_API_URL!,
-        kmsURL: process.env.PRIVY_KMS_URL!,
+        apiURL: PRIVY_API_URL!,
+        kmsURL: PRIVY_KMS_URL!,
         timeout: 0,
       },
     );

--- a/packages/privy-node/test/integration/index.test.ts
+++ b/packages/privy-node/test/integration/index.test.ts
@@ -38,14 +38,13 @@ describe('Privy client', () => {
   it('get / put api', async () => {
     let username: FieldInstance | null, email: FieldInstance | null;
 
-    // TODO(dave): Checking for initial nulls makes this test not re-runnable.
+    // TODO(#914): Handle null checks such that these tests can be re-run without failing.
+    email = await client.get(userID, 'email');
+    expect(email).toEqual(null);
 
-    // email = await client.get(userID, 'email');
-    // expect(email).toEqual(null);
-
-    // [username, email] = await client.get(userID, ['username', 'email']);
-    // expect(username).toEqual(null);
-    // expect(email).toEqual(null);
+    [username, email] = await client.get(userID, ['username', 'email']);
+    expect(username).toEqual(null);
+    expect(email).toEqual(null);
 
     [username, email] = await client.put(userID, [
       {field: 'username', value: 'tobias'},

--- a/packages/privy-node/test/integration/index.test.ts
+++ b/packages/privy-node/test/integration/index.test.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import {fetchAPIKeys} from './api_keys';
 import {PrivyClient, FieldInstance, BatchOptions} from '../../src';
+import uniqueId from '../unique_id';
 
 const PRIVY_API_URL = process.env.PRIVY_API_URL || 'http://127.0.0.1:2424/v0';
 const PRIVY_KMS_URL = process.env.PRIVY_KMS_URL || 'http://127.0.0.1:2424/v0';
@@ -85,44 +86,43 @@ describe('Privy client', () => {
     expect(downloadedFile!.contentType).toEqual('text/plain');
   });
 
-  // it('batch get / put api', async () => {
-  //   const user0 = `0x${Date.now()}`;
-  //   let username: FieldInstance | null, email: FieldInstance | null;
-  //   [username, email] = await client.put(user0, [
-  //     {field: 'username', value: 'tobias'},
-  //     {field: 'email', value: 'tobias@funke.com'},
-  //   ]);
-  //   const user1 = `0x${Date.now()}`;
-  //   [username] = await client.put(user1, [{field: 'username', value: 'michael'}]);
-  //   const user2 = `0x${Date.now()}`;
-  //   [username] = await client.put(user2, [{field: 'username', value: 'gob'}]);
+  it('batch get / put api', async () => {
+    const user0 = uniqueId();
+    let username: FieldInstance | null, email: FieldInstance | null;
+    [username, email] = await client.put(user0, [
+      {field: 'username', value: 'tobias'},
+      {field: 'email', value: 'tobias@funke.com'},
+    ]);
+    const user1 = uniqueId();
+    [username] = await client.put(user1, [{field: 'username', value: 'michael'}]);
+    const user2 = uniqueId();
+    [username] = await client.put(user2, [{field: 'username', value: 'gob'}]);
 
-  //   // Test missing cursor behavior.
-  //   let options: BatchOptions = {limit: 1};
-  //   let batchData = await client.getBatch(['username', 'email'], {
-  //     limit: 1,
-  //   });
-  //   expect(batchData.next_cursor_id).toEqual(user1);
-  //   expect(batchData.users.length).toEqual(1);
+    // Test missing cursor behavior.
+    let batchData = await client.getBatch(['username', 'email'], {
+      limit: 1,
+    });
+    expect(batchData.next_cursor_id).toEqual(user1);
+    expect(batchData.users.length).toEqual(1);
 
-  //   // Test data returned when cursor is provided.
-  //   batchData = await client.getBatch(['username', 'email'], {
-  //     cursor: user1,
-  //     limit: 2,
-  //   });
-  //   let users = batchData.users;
-  //   expect(users.length).toEqual(2);
-  //   // Check user0's data.
-  //   expect(users[0].data.length).toEqual(2);
-  //   username = users[0].data[0] as FieldInstance;
-  //   expect(username.text()).toEqual('michael');
-  //   email = users[0].data[1] as FieldInstance;
-  //   expect(email).toEqual(null);
-  //   // Check user1's data.
-  //   expect(users[1].data.length).toEqual(2);
-  //   username = users[1].data[0] as FieldInstance;
-  //   expect(username.text()).toEqual('tobias');
-  //   email = users[1].data[1] as FieldInstance;
-  //   expect(email.text()).toEqual('tobias@funke.com');
-  // });
+    // Test data returned when cursor is provided.
+    batchData = await client.getBatch(['username', 'email'], {
+      cursor: user1,
+      limit: 2,
+    });
+    let users = batchData.users;
+    expect(users.length).toEqual(2);
+    // Check user0's data.
+    expect(users[0].data.length).toEqual(2);
+    username = users[0].data[0] as FieldInstance;
+    expect(username.text()).toEqual('michael');
+    email = users[0].data[1] as FieldInstance;
+    expect(email).toEqual(null);
+    // Check user1's data.
+    expect(users[1].data.length).toEqual(2);
+    username = users[1].data[0] as FieldInstance;
+    expect(username.text()).toEqual('tobias');
+    email = users[1].data[1] as FieldInstance;
+    expect(email.text()).toEqual('tobias@funke.com');
+  });
 });

--- a/packages/privy-node/test/integration/index.test.ts
+++ b/packages/privy-node/test/integration/index.test.ts
@@ -31,60 +31,60 @@ describe('Privy client', () => {
     });
   });
 
-  // it('get / put api', async () => {
-  //   let username: FieldInstance | null, email: FieldInstance | null;
+  it('get / put api', async () => {
+    let username: FieldInstance | null, email: FieldInstance | null;
 
-  //   // TODO(dave): Checking for initial nulls makes this test not re-runnable.
+    // TODO(dave): Checking for initial nulls makes this test not re-runnable.
 
-  //   // email = await client.get(userID, 'email');
-  //   // expect(email).toEqual(null);
+    // email = await client.get(userID, 'email');
+    // expect(email).toEqual(null);
 
-  //   // [username, email] = await client.get(userID, ['username', 'email']);
-  //   // expect(username).toEqual(null);
-  //   // expect(email).toEqual(null);
+    // [username, email] = await client.get(userID, ['username', 'email']);
+    // expect(username).toEqual(null);
+    // expect(email).toEqual(null);
 
-  //   [username, email] = await client.put(userID, [
-  //     {field: 'username', value: 'tobias'},
-  //     {field: 'email', value: 'tobias@funke.com'},
-  //   ]);
+    [username, email] = await client.put(userID, [
+      {field: 'username', value: 'tobias'},
+      {field: 'email', value: 'tobias@funke.com'},
+    ]);
 
-  //   expect(username.integrity_hash).toEqual(expect.any(String));
-  //   expect(username.text()).toEqual('tobias');
-  //   expect(email.integrity_hash).toEqual(expect.any(String));
-  //   expect(email.text()).toEqual('tobias@funke.com');
-  //   expect(username.integrity_hash !== email.integrity_hash).toEqual(true);
+    expect(username.integrity_hash).toEqual(expect.any(String));
+    expect(username.text()).toEqual('tobias');
+    expect(email.integrity_hash).toEqual(expect.any(String));
+    expect(email.text()).toEqual('tobias@funke.com');
+    expect(username.integrity_hash !== email.integrity_hash).toEqual(true);
 
-  //   username = (await client.get(userID, 'username')) as FieldInstance;
-  //   expect(username.text()).toEqual('tobias');
+    username = (await client.get(userID, 'username')) as FieldInstance;
+    expect(username.text()).toEqual('tobias');
 
-  //   username = await client.put(userID, 'username', 'tobiasfunke');
-  //   expect(username.integrity_hash).toEqual(expect.any(String));
-  //   expect(username.text()).toEqual('tobiasfunke');
+    username = await client.put(userID, 'username', 'tobiasfunke');
+    expect(username.integrity_hash).toEqual(expect.any(String));
+    expect(username.text()).toEqual('tobiasfunke');
 
-  //   username = (await client.get(userID, 'username')) as FieldInstance;
-  //   expect(username.text()).toEqual('tobiasfunke');
+    username = (await client.get(userID, 'username')) as FieldInstance;
+    expect(username.text()).toEqual('tobiasfunke');
 
-  //   [username, email] = (await client.get(userID, ['username', 'email'])) as FieldInstance[];
-  //   expect(username.text()).toEqual('tobiasfunke');
-  //   expect(email.text()).toEqual('tobias@funke.com');
+    [username, email] = (await client.get(userID, ['username', 'email'])) as FieldInstance[];
+    expect(username.text()).toEqual('tobiasfunke');
+    expect(email.text()).toEqual('tobias@funke.com');
 
-  //   const integrityHash = email.integrity_hash;
+    const integrityHash = email.integrity_hash;
 
-  //   email = (await client.getByIntegrityHash(integrityHash)) as FieldInstance;
-  //   expect(email.text()).toEqual('tobias@funke.com');
-  //   expect(email.integrity_hash).toEqual(integrityHash);
-  // });
+    email = (await client.getByIntegrityHash(integrityHash)) as FieldInstance;
+    expect(email.text()).toEqual('tobias@funke.com');
+    expect(email.integrity_hash).toEqual(integrityHash);
+  });
 
-  // it('putFile / getFile api', async () => {
-  //   const file = await client.putFile(userID, 'avatar', Buffer.from('file_data'), 'text/plain');
-  //   expect(file.contentType).toEqual('text/plain');
-  //   expect(file.field_id).toEqual('avatar');
-  //   expect(file.user_id).toEqual(userID);
+  it('putFile / getFile api', async () => {
+    const file = await client.putFile(userID, 'avatar', Buffer.from('file_data'), 'text/plain');
+    expect(file.contentType).toEqual('text/plain');
+    expect(file.field_id).toEqual('avatar');
+    expect(file.user_id).toEqual(userID);
 
-  //   const downloadedFile = await client.getFile(userID, 'avatar');
-  //   expect(downloadedFile!.buffer().toString()).toEqual('file_data');
-  //   expect(downloadedFile!.contentType).toEqual('text/plain');
-  // });
+    const downloadedFile = await client.getFile(userID, 'avatar');
+    expect(downloadedFile!.buffer().toString()).toEqual('file_data');
+    expect(downloadedFile!.contentType).toEqual('text/plain');
+  });
 
   it('batch get / put api', async () => {
     // SETUP: Create 2 fields, initially with admin default access group for both.
@@ -111,15 +111,15 @@ describe('Privy client', () => {
     });
 
     const user0 = `user-${id}-0`;
-    let username: FieldInstance | null, email: FieldInstance | null;
-    [username, email] = await client.put(user0, [
+    let adminFieldVal: FieldInstance | null, selfFieldVal: FieldInstance | null;
+    [adminFieldVal, selfFieldVal] = await client.put(user0, [
       {field: adminDefaultField, value: 'admin-val-0'},
       {field: selfDefaultField, value: 'self-val-0'},
     ]);
     const user1 = `user-${id}-1`;
-    [username] = await client.put(user1, [{field: selfDefaultField, value: 'self-val-1'}]);
+    [selfFieldVal] = await client.put(user1, [{field: selfDefaultField, value: 'self-val-1'}]);
     const user2 = `user-${id}-2`;
-    [username] = await client.put(user2, [{field: adminDefaultField, value: 'admin-val-2'}]);
+    [adminFieldVal] = await client.put(user2, [{field: adminDefaultField, value: 'admin-val-2'}]);
 
     // Now change the default access group for the self field.
     field = await client.updateField(selfDefaultField, {default_access_group: 'self'});

--- a/packages/privy-node/test/integration/index.test.ts
+++ b/packages/privy-node/test/integration/index.test.ts
@@ -31,98 +31,163 @@ describe('Privy client', () => {
     });
   });
 
-  it('get / put api', async () => {
-    let username: FieldInstance | null, email: FieldInstance | null;
+  // it('get / put api', async () => {
+  //   let username: FieldInstance | null, email: FieldInstance | null;
 
-    // TODO(dave): Checking for initial nulls makes this test not re-runnable.
+  //   // TODO(dave): Checking for initial nulls makes this test not re-runnable.
 
-    // email = await client.get(userID, 'email');
-    // expect(email).toEqual(null);
+  //   // email = await client.get(userID, 'email');
+  //   // expect(email).toEqual(null);
 
-    // [username, email] = await client.get(userID, ['username', 'email']);
-    // expect(username).toEqual(null);
-    // expect(email).toEqual(null);
+  //   // [username, email] = await client.get(userID, ['username', 'email']);
+  //   // expect(username).toEqual(null);
+  //   // expect(email).toEqual(null);
 
-    [username, email] = await client.put(userID, [
-      {field: 'username', value: 'tobias'},
-      {field: 'email', value: 'tobias@funke.com'},
-    ]);
+  //   [username, email] = await client.put(userID, [
+  //     {field: 'username', value: 'tobias'},
+  //     {field: 'email', value: 'tobias@funke.com'},
+  //   ]);
 
-    expect(username.integrity_hash).toEqual(expect.any(String));
-    expect(username.text()).toEqual('tobias');
-    expect(email.integrity_hash).toEqual(expect.any(String));
-    expect(email.text()).toEqual('tobias@funke.com');
-    expect(username.integrity_hash !== email.integrity_hash).toEqual(true);
+  //   expect(username.integrity_hash).toEqual(expect.any(String));
+  //   expect(username.text()).toEqual('tobias');
+  //   expect(email.integrity_hash).toEqual(expect.any(String));
+  //   expect(email.text()).toEqual('tobias@funke.com');
+  //   expect(username.integrity_hash !== email.integrity_hash).toEqual(true);
 
-    username = (await client.get(userID, 'username')) as FieldInstance;
-    expect(username.text()).toEqual('tobias');
+  //   username = (await client.get(userID, 'username')) as FieldInstance;
+  //   expect(username.text()).toEqual('tobias');
 
-    username = await client.put(userID, 'username', 'tobiasfunke');
-    expect(username.integrity_hash).toEqual(expect.any(String));
-    expect(username.text()).toEqual('tobiasfunke');
+  //   username = await client.put(userID, 'username', 'tobiasfunke');
+  //   expect(username.integrity_hash).toEqual(expect.any(String));
+  //   expect(username.text()).toEqual('tobiasfunke');
 
-    username = (await client.get(userID, 'username')) as FieldInstance;
-    expect(username.text()).toEqual('tobiasfunke');
+  //   username = (await client.get(userID, 'username')) as FieldInstance;
+  //   expect(username.text()).toEqual('tobiasfunke');
 
-    [username, email] = (await client.get(userID, ['username', 'email'])) as FieldInstance[];
-    expect(username.text()).toEqual('tobiasfunke');
-    expect(email.text()).toEqual('tobias@funke.com');
+  //   [username, email] = (await client.get(userID, ['username', 'email'])) as FieldInstance[];
+  //   expect(username.text()).toEqual('tobiasfunke');
+  //   expect(email.text()).toEqual('tobias@funke.com');
 
-    const integrityHash = email.integrity_hash;
+  //   const integrityHash = email.integrity_hash;
 
-    email = (await client.getByIntegrityHash(integrityHash)) as FieldInstance;
-    expect(email.text()).toEqual('tobias@funke.com');
-    expect(email.integrity_hash).toEqual(integrityHash);
-  });
+  //   email = (await client.getByIntegrityHash(integrityHash)) as FieldInstance;
+  //   expect(email.text()).toEqual('tobias@funke.com');
+  //   expect(email.integrity_hash).toEqual(integrityHash);
+  // });
 
-  it('putFile / getFile api', async () => {
-    const file = await client.putFile(userID, 'avatar', Buffer.from('file_data'), 'text/plain');
-    expect(file.contentType).toEqual('text/plain');
-    expect(file.field_id).toEqual('avatar');
-    expect(file.user_id).toEqual(userID);
+  // it('putFile / getFile api', async () => {
+  //   const file = await client.putFile(userID, 'avatar', Buffer.from('file_data'), 'text/plain');
+  //   expect(file.contentType).toEqual('text/plain');
+  //   expect(file.field_id).toEqual('avatar');
+  //   expect(file.user_id).toEqual(userID);
 
-    const downloadedFile = await client.getFile(userID, 'avatar');
-    expect(downloadedFile!.buffer().toString()).toEqual('file_data');
-    expect(downloadedFile!.contentType).toEqual('text/plain');
-  });
+  //   const downloadedFile = await client.getFile(userID, 'avatar');
+  //   expect(downloadedFile!.buffer().toString()).toEqual('file_data');
+  //   expect(downloadedFile!.contentType).toEqual('text/plain');
+  // });
 
   it('batch get / put api', async () => {
+    // SETUP: Create 2 fields, initially with admin default access group for both.
+    const id = uniqueId();
+    const adminField = `field-${id}-2`;
+    // This field will later have `self` set as the default access group.
+    const selfField = `field-${id}-1`;
+
+    let field;
+    field = await client.createField({name: selfField, default_access_group: 'admin'});
+    expect(field).toMatchObject({
+      field_id: selfField,
+      name: selfField,
+      default_access_group: 'admin',
+      updated_at: expect.any(Number),
+    });
+
+    field = await client.createField({name: adminField, default_access_group: 'admin'});
+    expect(field).toMatchObject({
+      field_id: adminField,
+      name: adminField,
+      default_access_group: 'admin',
+      updated_at: expect.any(Number),
+    });
+
     const user0 = uniqueId();
     let username: FieldInstance | null, email: FieldInstance | null;
     [username, email] = await client.put(user0, [
-      {field: 'username', value: 'tobias'},
-      {field: 'email', value: 'tobias@funke.com'},
+      {field: adminField, value: 'admin-val-0'},
+      {field: selfField, value: 'self-val-0'},
     ]);
     const user1 = uniqueId();
-    [username] = await client.put(user1, [{field: 'username', value: 'michael'}]);
+    [username] = await client.put(user1, [{field: adminField, value: 'admin-val-1'}]);
     const user2 = uniqueId();
-    [username] = await client.put(user2, [{field: 'username', value: 'gob'}]);
+    [username] = await client.put(user2, [{field: selfField, value: 'self-val-2'}]);
+    console.log('user0:', user0);
+    console.log('user1:', user0);
+    console.log('user2:', user0);
 
-    // Test missing cursor behavior.
-    let batchData = await client.getBatch(['username', 'email'], {
-      limit: 1,
+    // Now change the default access group for the self field.
+    field = await client.updateField(selfField, {default_access_group: 'self'});
+    expect(field).toMatchObject({
+      field_id: selfField,
+      name: selfField,
+      default_access_group: 'self',
+      updated_at: expect.any(Number),
     });
-    expect(batchData.next_cursor_id).toEqual(user1);
-    expect(batchData.users.length).toEqual(1);
 
-    // Test data returned when cursor is provided.
-    batchData = await client.getBatch(['username', 'email'], {
-      cursor: user1,
-      limit: 2,
+    field = await client.updateField(selfField, {default_access_group: 'self'});
+    expect(field).toMatchObject({
+      field_id: selfField,
+      name: selfField,
+      default_access_group: 'self',
+      updated_at: expect.any(Number),
     });
-    let users = batchData.users;
-    expect(users.length).toEqual(2);
-    // Check user0's data.
-    expect(users[0].data.length).toEqual(2);
-    username = users[0].data[0] as FieldInstance;
-    expect(username.text()).toEqual('michael');
-    email = users[0].data[1] as FieldInstance;
-    expect(email).toEqual(null);
-    // Check user1's data.
-    expect(users[1].data.length).toEqual(2);
-    username = users[1].data[0] as FieldInstance;
-    expect(username.text()).toEqual('tobias');
-    email = users[1].data[1] as FieldInstance;
-    expect(email.text()).toEqual('tobias@funke.com');
+
+    // Update user0's selfField's access group to a custom access group with read admin perms.
+    // CREATE the access group
+    const testAccessGroupId = `test-access-group-${id}`;
+    const accessGroup = await client.createAccessGroup({
+      name: testAccessGroupId,
+      read_roles: ['admin'],
+      write_roles: ['self'],
+    });
+    expect(accessGroup).toMatchObject({
+      access_group_id: testAccessGroupId,
+      name: testAccessGroupId,
+      read_roles: ['admin'],
+      write_roles: ['self'],
+      is_default: false,
+    });
+    let permissions = await client.updateUserPermissions(user0, [
+      {field_id: selfField, access_group: testAccessGroupId},
+    ]);
+    expect(permissions).toEqual(
+      expect.arrayContaining([{field_id: selfField, access_group: testAccessGroupId}]),
+    );
+
+    // TEST: Check missing cursor returns oldest user.
+    // let batchData = await client.getBatch([adminField, selfField], {
+    //   limit: 1,
+    // });
+    // expect(batchData.next_cursor_id).toEqual(user1);
+    // expect(batchData.users.length).toEqual(1);
+
+    //   // Test data returned when cursor is provided.
+    //   batchData = await client.getBatch(['username', 'email'], {
+    //     cursor: user1,
+    //     limit: 2,
+    //   });
+    //   let users = batchData.users;
+    //   expect(users.length).toEqual(2);
+    //   // Check user0's data.
+    //   expect(users[0].data.length).toEqual(2);
+    //   username = users[0].data[0] as FieldInstance;
+    //   expect(username.text()).toEqual('michael');
+    //   email = users[0].data[1] as FieldInstance;
+    //   expect(email).toEqual(null);
+    //   // Check user1's data.
+    //   expect(users[1].data.length).toEqual(2);
+    //   username = users[1].data[0] as FieldInstance;
+    //   expect(username.text()).toEqual('tobias');
+    //   email = users[1].data[1] as FieldInstance;
+    //   expect(email.text()).toEqual('tobias@funke.com');
   });
 });


### PR DESCRIPTION
Land pagination changes back into privy-node, now that https://github.com/privy-io/privy/pull/909 moves them to new perms.

cc: @asta-li, @benjreinhart 