### PR TITLE
Add explicit error response logging to sendEmail

### DIFF
--- a/packages/privy-node/src/client.ts
+++ b/packages/privy-node/src/client.ts
@@ -761,8 +761,9 @@ export class PrivyClient extends PrivyConfig {
         },
         undefined,
       );
-    } catch (error) {
-      throw formatPrivyError(error);
+    } catch (error: any) {
+      const errorType = error?.type || error?.statusText || error?.status || 'Unknown error';
+      throw new PrivyClientError(`${errorType}: email send failed for user ${userId}`);
     }
   }
 }


### PR DESCRIPTION
Due to the nature of the send API, we should make an explicit attempt to process the response from the API before we raise, as all errors are logged to the host running the code. If we don't, the error may contain sensitive request context and undesirable to log.