### PR TITLE
Add and export type for field instance requests

### DIFF
--- a/packages/privy-browser/src/client.ts
+++ b/packages/privy-browser/src/client.ts
@@ -18,6 +18,7 @@ import {
   EncryptedUserDataResponseValue,
   EncryptedUserDataRequestValue,
   FileMetadata,
+  UpdateFieldInstanceRequest,
   WrapperKeyResponse,
 } from './types';
 import {FieldInstance} from './fieldInstance';
@@ -151,10 +152,10 @@ export class PrivyClient {
    * @param fields Array of objects with `field` and `value` keys.
    * @returns Array of {@link FieldInstance}s of the updated fields, in the same order as the input.
    */
-  async put(userId: string, fields: {field: string; value: string}[]): Promise<FieldInstance[]>;
+  async put(userId: string, fields: UpdateFieldInstanceRequest[]): Promise<FieldInstance[]>;
   async put(
     userId: string,
-    fields: string | {field: string; value: string}[],
+    fields: string | UpdateFieldInstanceRequest[],
     value?: string,
   ): Promise<FieldInstance | FieldInstance[]> {
     const data = typeof fields === 'string' ? [{field: fields, value: value!}] : fields;
@@ -348,7 +349,7 @@ export class PrivyClient {
 
   private async encrypt(
     userId: string,
-    data: {field: string; value: string}[],
+    data: UpdateFieldInstanceRequest[],
   ): Promise<EncryptedUserDataRequestValue[]> {
     const wrapperKeys = await this.getWrapperKeys(
       userId,

--- a/packages/privy-browser/src/index.ts
+++ b/packages/privy-browser/src/index.ts
@@ -6,5 +6,6 @@ export {SiweSession} from './sessions/siwe';
 export {PublicSession} from './sessions/public';
 
 export {FieldInstance} from './fieldInstance';
+export {UpdateFieldInstanceRequest} from './types';
 
 export {PrivyError, PrivyApiError, PrivyClientError, PrivySessionError} from './errors';

--- a/packages/privy-browser/src/types.ts
+++ b/packages/privy-browser/src/types.ts
@@ -45,3 +45,8 @@ export interface FileMetadata {
   commitment_id: string;
   created_at: number;
 }
+
+export interface UpdateFieldInstanceRequest {
+  field: string;
+  value: string;
+}

--- a/packages/privy-node/src/client.ts
+++ b/packages/privy-node/src/client.ts
@@ -27,12 +27,12 @@ import {
   DataKeyBatchResponse,
   DataKeyResponseValue,
 } from './types';
+import {UpdateFieldInstanceRequest} from './model/requests';
 import {FieldInstance, BatchFieldInstances, UserFieldInstances} from './fieldInstance';
 import {formatPrivyError, PrivyClientError} from './errors';
 import encoding, {wrapAsBuffer} from './encoding';
 import {md5} from './hash';
 import {PrivyConfig, SigningFn} from './config';
-import crypto from 'crypto';
 import Handlebars from 'handlebars';
 
 // At the moment, there is only one version of
@@ -195,10 +195,10 @@ export class PrivyClient extends PrivyConfig {
    * @param fields Array of objects with `field` and `value` keys.
    * @returns Array of {@link FieldInstance}s of the updated fields, in the same order as the input.
    */
-  async put(userId: string, fields: {field: string; value: string}[]): Promise<FieldInstance[]>;
+  async put(userId: string, fields: UpdateFieldInstanceRequest[]): Promise<FieldInstance[]>;
   async put(
     userId: string,
-    fields: string | {field: string; value: string}[],
+    fields: string | UpdateFieldInstanceRequest[],
     value?: string,
   ): Promise<FieldInstance | FieldInstance[]> {
     const data = typeof fields === 'string' ? [{field: fields, value: value!}] : fields;
@@ -401,7 +401,7 @@ export class PrivyClient extends PrivyConfig {
 
   private async encrypt(
     userId: string,
-    data: {field: string; value: string}[],
+    data: UpdateFieldInstanceRequest[],
   ): Promise<EncryptedUserDataRequestValue[]> {
     const wrapperKeys = await this.getWrapperKeys(
       userId,

--- a/packages/privy-node/src/index.ts
+++ b/packages/privy-node/src/index.ts
@@ -7,10 +7,12 @@ export {
   UpdateRoleRequest,
   CreateRoleRequest,
   CreateAccessGroupRequest,
-  UpdateFieldRequest,
   UpdateAccessGroupRequest,
+  UpdateFieldRequest,
+  UpdateFieldInstanceRequest,
   EncryptedAliasRequestValue,
 } from './model/requests';
+
 export {AccessGroup, AccessTokenClaims, Field, Role, UserPermission} from './model/data';
 
 export {FieldInstance, BatchFieldInstances, UserFieldInstances} from './fieldInstance';

--- a/packages/privy-node/src/model/requests.ts
+++ b/packages/privy-node/src/model/requests.ts
@@ -37,6 +37,11 @@ export interface UpdateRoleRequest {
   description?: string;
 }
 
+export interface UpdateFieldInstanceRequest {
+  field: string;
+  value: string;
+}
+
 /**
  * The required attributes of an access group
  */


### PR DESCRIPTION
Violet requested an exported type for the `{field: string, value: string}` argument.

cc @zacharyliu 